### PR TITLE
Add Mocha and Jest under Unit Testing section

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ __Visual Regression__
 
 __Unit Testing__
 - [Jasmine](http://jasmine.github.io/)
+- [Jest](https://facebook.github.io/jest/)
+- [Mocha](http://visionmedia.github.io/mocha/)
 
 ### Documentation Tools
 - [The Styleguide Guide](http://vinspee.me/style-guide-guide/)


### PR DESCRIPTION
[Mocha](http://visionmedia.github.io/mocha/) is a fairly well established alternative to
Jasmine for JS unit testing.

[Jest](https://facebook.github.io/jest/) is new, and built "on top of" Jasmine. If that one
doesn't fit, I'm happy to amend the commit and remove it.
