### PR TITLE
Fixes code block by escaping backticks.

### DIFF
--- a/book-examples/04-documentation-pillar/chapter-15-style-guides.md
+++ b/book-examples/04-documentation-pillar/chapter-15-style-guides.md
@@ -39,9 +39,9 @@ category: Base CSS
 
 This is our button
 
-```html_example
+\```html_example
 <a class="btn" href="#">Click</a>
-```
+\```
 */
 
 


### PR DESCRIPTION
In order to use triple backticks "```" inside a code block they need to be escaped.

There was an instance in book-examples/04-documentation-pillar/chapter-15-style-guides.md where this was not done, causing the text to not be properly formatted.

This pull request fixes that.
